### PR TITLE
Fixed docker-compose for making Windows GUIs work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     privileged: true
     volumes:
       - .:/mission9-2021:rw  # Copy code into Docker container
-      # GUI Settings for Linux only...?
       - $HOME/.Xauthority:/root/.Xauthority:rw
       - /tmp/.X11-unix:/tmp/.X11-unix
     environment:
@@ -21,15 +20,12 @@ services:
     privileged: true
     volumes:
       - .:/mission9-2021:rw  # Copy code into Docker container
-      # TODO Fix GUI settings for Windows
-      - $HOME/.Xauthority:/root/.Xauthority:rw
-      - /tmp/.X11-unix:/tmp/.X11-unix
     environment:
       - DISPLAY
+      # - LIBGL_ALWAYS_INDIRECT=1  # Does not work when enabled
     network_mode: "host"
     container_name: maav-mission9
     command: "/bin/bash --init-file scripts/source-ros.sh"
-
 
   mac:
     image: maav-mission9


### PR DESCRIPTION
This removes unnecessary components to the docker-compose WSL service. Additionally, this will allow Gazebo GUI to work on WSL / Windows machines